### PR TITLE
feat: add support for application_credentials

### DIFF
--- a/internal/clients/openstack.go
+++ b/internal/clients/openstack.go
@@ -65,9 +65,22 @@ func TerraformSetupBuilder(version, providerSource, providerVersion string) terr
 		// Set credentials in Terraform provider configuration.
 		ps.Configuration = map[string]any{
 			"auth_url":    creds["auth_url"],
-			"tenant_name": creds["tenant_name"],
-			"user_name":   creds["user_name"],
-			"password":    creds["password"],
+		}
+
+		if val, exists := creds["tenant_name"]; exists {
+			ps.Configuration["tenant_name"]= val
+		}
+		if val, exists := creds["user_name"]; exists {
+			ps.Configuration["user_name"]= val
+		}
+		if val, exists := creds["password"]; exists {
+			ps.Configuration["password"]= val
+		}
+		if val, exists := creds["application_credential_id"]; exists {
+			ps.Configuration["application_credential_id"]= val
+		}
+		if val, exists := creds["application_credential_secret"]; exists {
+			ps.Configuration["application_credential_secret"]= val
 		}
 		return ps, nil
 	}

--- a/internal/clients/openstack.go
+++ b/internal/clients/openstack.go
@@ -64,23 +64,12 @@ func TerraformSetupBuilder(version, providerSource, providerVersion string) terr
 
 		// Set credentials in Terraform provider configuration.
 		ps.Configuration = map[string]any{
-			"auth_url":    creds["auth_url"],
-		}
-
-		if val, exists := creds["tenant_name"]; exists {
-			ps.Configuration["tenant_name"]= val
-		}
-		if val, exists := creds["user_name"]; exists {
-			ps.Configuration["user_name"]= val
-		}
-		if val, exists := creds["password"]; exists {
-			ps.Configuration["password"]= val
-		}
-		if val, exists := creds["application_credential_id"]; exists {
-			ps.Configuration["application_credential_id"]= val
-		}
-		if val, exists := creds["application_credential_secret"]; exists {
-			ps.Configuration["application_credential_secret"]= val
+			"auth_url":                      creds["auth_url"],
+			"tenant_name":                   creds["tenant_name"],
+			"user_name":                     creds["user_name"],
+			"password":                      creds["password"],
+			"application_credential_id":     creds["application_credential_id"],
+			"application_credential_secret": creds["application_credential_secret"],
 		}
 		return ps, nil
 	}


### PR DESCRIPTION
### Description of your changes

This PR adds support for Openstack Application credentials. So that you do not have to use "username" and plain text "password" for authentification. 

Learn more about "Application Credentials" here: https://docs.openstack.org/keystone/queens/user/application_credentials.html 

### How has this code been tested

I tested the code with `make run`- provider. 

[contribution process]: https://git.io/fj2m9
